### PR TITLE
Fixes TestPrEnvironment not running during self-update

### DIFF
--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
 
 jobs:
   create-auto-pr:
@@ -19,12 +18,12 @@ jobs:
         id: prepautopr
         uses: platformsh/prep-for-autopr@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
 
       - name: 'Create & merge PR'
         id: create-merge-pr
         uses: platformsh/create-autopr@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
           trigger-source: 'auto push'
           default-branch: ${{ steps.prepautopr.outputs.default-branch }}

--- a/.github/workflows/testprenvironment.yaml
+++ b/.github/workflows/testprenvironment.yaml
@@ -13,6 +13,7 @@ jobs:
   test-pr-env:
     name: TestPrEnvironment
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
       - name: 'Wait for psh and get target url'
         id: get-target-url


### PR DESCRIPTION
Limits the workflow action `TestPrEnvironment` to only run if the owner is `platformsh-templates`

Changes the token used with the actions in autopr.yaml to explicitly use `TEMPLATES_GITHUB_TOKEN`. This should correct the issue we saw with the `TestPrEnvironment` status check not being triggered due to the same bot running both. This is specifically not allowed:

> PRs that are created by an action will not trigger any actions waiting on a pull request event. This is a deliberate decision by the Actions team in order to prevent accidental “infinite loop” situations, and as an anti-abuse measure.