### PR TITLE
removes ini_set calls from wp-config.php

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,6 +16,13 @@ dependencies:
         composer/composer: '^2'
         wp-cli/wp-cli-bundle: "^2.4.0"
 
+variables:
+  php:
+    session.gc_maxlifetime: '200000'
+    session.cookie_lifetime: '2000000'
+    pcre.backtrack_limit: '200000'
+    pcre.recursion_limit: '200000'
+
 hooks:
     build: |
         set -e
@@ -79,4 +86,4 @@ source:
     auto-update:
       command: |
         curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
-    
+

--- a/wp-config.php
+++ b/wp-config.php
@@ -112,14 +112,6 @@ define( 'WP_AUTO_UPDATE_CORE', false );
 // prefix.
 $table_prefix  = 'wp_';
 
-// Default PHP settings.
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
-ini_set('pcre.backtrack_limit', 200000);
-ini_set('pcre.recursion_limit', 200000);
-
 /** Absolute path to the WordPress directory. */
 if ( ! defined( 'ABSPATH' ) ) {
   define( 'ABSPATH', dirname( __FILE__ ) . '/' );


### PR DESCRIPTION
## Description
adds the php.ini settings that were in wp-config.php to .platform.app.yaml
Closes #76 

## Related Issue
#76 

### Please drop a link to the issue here:
#76 

## Motivation and Context
see #76 

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
