### PR TITLE
changes name of environmental variable from PLATFORMSH_PROJECT_ID to PLATFORM_PROJECT

### DIFF
--- a/.github/workflows/sourceops.yaml
+++ b/.github/workflows/sourceops.yaml
@@ -37,7 +37,7 @@ jobs:
 
           projIDpttrn='\/projects\/([^\/]+)\/integrations'
           if [[ "${integrationURL}" =~ ${projIDpttrn} ]]; then
-               echo "PLATFORMSH_PROJECT_ID=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+               echo "PLATFORM_PROJECT=${BASH_REMATCH[1]}" >> $GITHUB_ENV
                #echo "::set-output name=projectID::${BASH_REMATCH[1]}"
           else
               echo "::error::We were unable to extract the project ID from the integration url of ${integrationURL}"


### PR DESCRIPTION
## Description
changes name of environmental variable from PLATFORMSH_PROJECT_ID to PLATFORM_PROJECT in .github/workflows/sourceops.yaml

## Related Issue
Closes #79 

## Motivation and Context
Workflow was able to retrieve the project ID but was storing it with the wrong environmental variable name. When the cli later attempted to access information about the project, it was unable to given a project id was not properly set.

## How Has This Been Tested?
https://github.com/gilzow/wordpress-composer-sourceop-debug/runs/7955046745?check_suite_focus=true#step:6:1

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
