### PR TITLE
Update/workflows revised

### DIFF
--- a/.github/workflows/sourceops.yaml
+++ b/.github/workflows/sourceops.yaml
@@ -15,43 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
-      - name: 'Setup Python'
-        uses: actions/setup-python@v2
+      - name: 'Run source ops'
+        id: run-source-op
+        uses: platformsh/gha-run-sourceops-update@main
         with:
-          python-version: '3.x'
-      - name: "Install PSH CLI tool"
-        run: |
-          curl -fsS https://platform.sh/cli/installer | php
-          # for some reason, sourcing our .bashrc file does not successfully prepend our path to PATH
-          export PATH="${HOME}/.platformsh/bin:${PATH}"
-      - uses: actions/checkout@v2
-      - name: 'Get project ID'
-        run: |
-          # grab the array entries where config.url contain 'platform.sh' then map back to an array. if our
-          # array length is 1, return the entry for config.url, otherwise return error
-          integrationURL=$(gh api "/repos/${{ github.repository }}/hooks" | jq 'map(select(.config.url | contains("platform.sh"))) | if . | length == 1 then .[0].config.url else "error" end')
-          if [[ "error" == "${integrationURL}" ]]; then
-              echo "::error::Either more than one webhook, or zero webhooks were returned. I was expecting just one."
-              exit 1
-          fi
-
-          projIDpttrn='\/projects\/([^\/]+)\/integrations'
-          if [[ "${integrationURL}" =~ ${projIDpttrn} ]]; then
-               echo "PLATFORM_PROJECT=${BASH_REMATCH[1]}" >> $GITHUB_ENV
-               echo "::notice::Project ID is ${BASH_REMATCH[1]}"
-               #echo "::set-output name=projectID::${BASH_REMATCH[1]}"
-          else
-              echo "::error::We were unable to extract the project ID from the integration url of ${integrationURL}"
-              exit 1
-          fi
-
-      - name: 'Run SourceOp Tools'
-        run: |
-          if [[ "${PATH}" != *".platformsh"* ]]; then
-            echo "psh installer not in PATH"
-            export PATH="${HOME}/.platformsh/bin:${PATH}"
-          fi
-          printf "Beginning Source Operations toolkit install...\n"
-
-          curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 trigger-sopupdate; } 3<&0
-
+          github_token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+          platformsh_token: ${{ secrets.TEMPLATES_CLI_TOKEN }}

--- a/.github/workflows/testprenvironment.yaml
+++ b/.github/workflows/testprenvironment.yaml
@@ -9,7 +9,7 @@ on:
       - master
       - main
 env:
-  BASELINE_URL: ${{ vars.BASELINE_URL }}
+  # @todo I dont think this is needed anymore
   GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
 jobs:
   test-pr-env:
@@ -17,9 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
+      - name: 'Get Project ID'
+        id: 'get-proj-id'
+        uses: platformsh/gha-retrieve-projectid@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Get Production URL'
+        id: 'get-prod-url'
+        uses: platformsh/gha-retrieve-production-url@main
+        with:
+          platformsh_token: ${{ secrets.TEMPLATES_CLI_TOKEN }}
+          project_id: ${{ steps.get-proj-id.outputs.project_id }}
+
       - name: 'Run Pull Request Tests'
         id: get-target-url
         uses: platformsh/gha-template-pr-tests@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          baseline-url: ${{ vars.BASELINE_URL }}
+          baseline-url: ${{ steps.get-prod-url.outputs.production_url }}

--- a/.github/workflows/testprenvironment.yaml
+++ b/.github/workflows/testprenvironment.yaml
@@ -21,7 +21,7 @@ jobs:
         id: 'get-proj-id'
         uses: platformsh/gha-retrieve-projectid@main
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
 
       - name: 'Get Production URL'
         id: 'get-prod-url'


### PR DESCRIPTION
## Description
Changes the sourceops workflow to use the [platformsh/gha-run-sourceops-update](https://github.com/platformsh/gha-run-sourceops-update) action 
Changes the testprenvironment.yaml to use [platformsh/gha-retrieve-projectid](https://github.com/platformsh/gha-retrieve-projectid) and [platformsh/gha-retrieve-production-url](https://github.com/platformsh/gha-retrieve-production-url) in order to retrieve the production URL instead of relying on a repository secret.

