### PR TITLE
adds missing colon to bash parameter expansion

### DIFF
--- a/.github/workflows/tb-sync.yaml
+++ b/.github/workflows/tb-sync.yaml
@@ -105,7 +105,7 @@ jobs:
               # if the remote branch already exists, then we need to check it out from origin. otherwise, create a new
               # local branch that we'll push up later
               # @todo is there a way to retrieve the remote name instead of assuming it is 'origin'?
-              git checkout -b "${SYNC_BRANCH}" "${remoteBranch+origin/${SYNC_BRANCH}}"
+              git checkout -b "${SYNC_BRANCH}" "${remoteBranch:+origin/${SYNC_BRANCH}}"
 
               # go ahead and get the data on the files that were changed in the commit
               prFileData=$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${{ env.PRNUMBER }}/files")


### PR DESCRIPTION
## Description
we were missing an important `:` in one of our bash parameter expansions