### PR TITLE
remove globbing from rsync command in build hook

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -31,7 +31,7 @@ hooks:
         set -e
         # Copy manually-provided plugins into the plugins directory.
         # This allows manually-provided and composer-provided plugins to coexist.
-        rsync -a plugins/* wordpress/wp-content/plugins/
+        rsync -a plugins/ wordpress/wp-content/plugins/
 
     # The deploy hook is run after the app container has been started, but before it has started accepting requests.
     # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook


### PR DESCRIPTION
## Description
build hook is using globbing on rysnc to match files that should be sync'ed. however, globbing will not expand hidden files in this manner. This means hidden files/directories are potentially skipped.

